### PR TITLE
Make socket backlog configurable

### DIFF
--- a/README.md
+++ b/README.md
@@ -80,6 +80,9 @@ Finally, we register the resource with the server, and start a thread to handle 
 * `*protocol-76/00-support*`: set to T to enable support for [draft-hixie-76][hixie]/[draft-ietf-hybi-00][0] protocol  
   No longer used by current browsers, and doesn't support binary frames. May go away soon.
 
+* `*default-socket-backlog*`: default socket backlog parameter for the server listener (default: 5).
+  Controls how many pending connections can be queued before the OS starts rejecting them. Can be overridden with the `:backlog` keyword argument to `run-server`.
+
 * `*max-clients*`: maximum number of simultaneous connections allowed, or `NIL` for no limit
 
 * `*max-read-frame-size*`, `*max-read-message-size*`: maximum 'frame' and 'message' sizes allowed from clients.  

--- a/config.lisp
+++ b/config.lisp
@@ -5,6 +5,10 @@
 (defvar *protocol-76/00-support* nil
   "set to NIL to disable draft-hixie-76/draft-ietf-00 support, true to enable.")
 
+(defvar *default-socket-backlog* 5
+  "Default socket backlog parameter for the server listener. Controls how many
+pending connections can be queued before the OS starts rejecting them.")
+
 (defvar *max-clients* 256
   "Max number of simultaneous clients allowed (nil for no limit).
 Extra connections will get a HTTP 5xx response (without reading headers).")

--- a/server.lisp
+++ b/server.lisp
@@ -57,10 +57,15 @@ connections and has a bunch of client instances that it controls."))
            ;; otherwise handle normally
            (add-reader-to-client client)))))))
 
-(defun run-server (port &key (addr +ipv4-unspecified+))
+(defun run-server (port &key (addr +ipv4-unspecified+) (backlog *default-socket-backlog*))
   "Starts a server on the given PORT and blocks until the server is
 closed.  Intended to run in a dedicated thread (the current one),
 dubbed the Server Thread.
+
+Arguments:
+  PORT - Port number to listen on
+  ADDR - Address to bind to (defaults to +ipv4-unspecified+)
+  BACKLOG - Socket backlog for pending connections (defaults to *default-socket-backlog*)
 
 Establishes a socket listener in the current thread.  This thread
 handles all incoming connections, and because of this fact is able to
@@ -101,7 +106,7 @@ are thread-safe.
                                              ;; bind and listen as well
                                              :local-host addr
                                              :local-port port
-                                             :backlog 5
+                                             :backlog backlog
                                              :reuse-address t
                                              #++ :no-delay)
                (iolib:set-io-handler event-base


### PR DESCRIPTION
- Add *default-socket-backlog* configuration variable (defaults to 5)
- Add :backlog keyword argument to run-server function
- Update documentation for the new configuration option